### PR TITLE
fix(a11y): added missing alt attribute to the image

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -12,7 +12,7 @@
 <body>
   <div id="header">
     <div id="logo">
-    <img src="Chromebooks-in-Deuschland-logo.svg">
+    <img src="Chromebooks-in-Deuschland-logo.svg" alt="Chromebook">
     Chromebooks in Deutschland
     </div>
     <div class="box-right">


### PR DESCRIPTION
Informative elements should aim for short, descriptive alternate text. Decorative elements can be ignored with an empty alt attribute. [Learn more](https://web.dev/image-alt/?utm_source=lighthouse&utm_medium=lr).